### PR TITLE
allow options requests

### DIFF
--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -147,6 +147,12 @@ static ngx_int_t ngx_http_auth_jwt_handler(ngx_http_request_t *r)
 	{
 		return NGX_DECLINED;
 	}
+
+	// pass through options requests without token authentication
+	if (r->method == NGX_HTTP_OPTIONS)
+	{
+		return NGX_DECLINED;
+	}
 	
 	jwtCookieValChrPtr = getJwt(r, jwtcf->auth_jwt_validation_type);
 	if (jwtCookieValChrPtr == NULL)


### PR DESCRIPTION
I've started using a different subdomain for my front end and back end.  Suddenly, my app has started making OPTIONS requests.  When the request is made, it does not pass the token!  Apparently this is according to spec. I considered configuring NGINX to handle the OPTIONS requests, but I'd rather let my app handle it.