### PR TITLE
Fix possible overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ stop-nginx:
 start-nginx:
 	docker run --rm --name "$(DOCKER_IMAGE_NAME)-cont" -d -p 8000:8000 $(DOCKER_ORG_NAME)/$(DOCKER_IMAGE_NAME)
 	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/lib64/nginx/modules/ngx_http_auth_jwt_module.so .
-	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/libjansson.so.4.13.0 .
+	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/libjansson.so.4.10.0 .
 	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/libjwt.a .
 	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/libjwt.la .
-	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/libjwt.so.0.7.0 .
+	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/libjwt.so.0.4.0 .
 	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/pkgconfig/jansson.pc .
 	docker cp $(DOCKER_IMAGE_NAME)-cont:/usr/local/lib/pkgconfig/libjwt.pc .
 

--- a/src/ngx_http_auth_jwt_binary_converters.c
+++ b/src/ngx_http_auth_jwt_binary_converters.c
@@ -39,7 +39,8 @@ int hex_to_binary( const char* str, u_char* buf, int len )
 		return -1;
 	}
 
-	for (int i = 0; i < len; i += 2) {
+	int i;
+	for (i = 0; i < len; i += 2) {
 		hex_char_to_binary( *(str + i), &high );
 		hex_char_to_binary( *(str + i + 1 ), &low );
 		

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -424,13 +424,16 @@ static char * getJwt(ngx_http_request_t *r, ngx_str_t auth_jwt_validation_type)
 		if (authorizationHeader != NULL)
 		{
 			ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Found authorization header len %d", authorizationHeader->value.len);
+			n = authorizationHeader->value.len - (sizeof("Bearer ") - 1);
 
-			authorizationHeaderStr.data = authorizationHeader->value.data + sizeof("Bearer ") - 1;
-			authorizationHeaderStr.len = authorizationHeader->value.len - (sizeof("Bearer ") - 1);
+			if (n > 0) {
+				authorizationHeaderStr.data = authorizationHeader->value.data + sizeof("Bearer ") - 1;
+				authorizationHeaderStr.len = n;
 
-			jwtCookieValChrPtr = ngx_str_t_to_char_ptr(r->pool, authorizationHeaderStr);
+				jwtCookieValChrPtr = ngx_str_t_to_char_ptr(r->pool, authorizationHeaderStr);
 
-			ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Authorization header: %s", jwtCookieValChrPtr);
+				ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0, "Authorization header: %s", jwtCookieValChrPtr);
+			}
 		}
 	}
 	else if (auth_jwt_validation_type.len > sizeof("COOKIE=") && ngx_strncmp(auth_jwt_validation_type.data, "COOKIE=", sizeof("COOKIE=") - 1)==0)

--- a/test.sh
+++ b/test.sh
@@ -38,6 +38,8 @@ main() {
 
   test_jwt "Secure test without jwt auth header" "/secure-no-redirect/" "401"
 
+  test_jwt "Secure test with jwt auth header missing Bearer" "/secure-no-redirect/" "401" "--header \"Authorization: X\""
+
   test_jwt "Secure test with jwt cookie - with no sub" "/secure/" "200" " --cookie \"rampartjwt=${MISSING_SUB_JWT}\""
 
   test_jwt "Secure test with jwt cookie - with no email" "/secure/" "200" " --cookie \"rampartjwt=${MISSING_EMAIL_JWT}\""


### PR DESCRIPTION
Fix segfault when a bad Authorization header is issued (contains no "Bearer", total length < 6).

Other changes:
* Fix start-nginx in Makefile (for unit tests)
* Declare `i` variable for loop, to prevent C99 mode requirement for gcc
* Add unit test for bad Authorization header

Resolves #40 