### PR TITLE
Modify 'in' headers instead of 'out' headers

### DIFF
--- a/src/ngx_http_auth_jwt_header_processing.c
+++ b/src/ngx_http_auth_jwt_header_processing.c
@@ -71,7 +71,7 @@ ngx_int_t set_custom_header_in_headers_out(ngx_http_request_t *r, ngx_str_t *key
     /*
     All we have to do is just to allocate the header...
     */
-    h = ngx_list_push(&r->headers_out.headers);
+    h = ngx_list_push(&r->headers_in.headers);
     if (h == NULL) {
         return NGX_ERROR;
     }


### PR DESCRIPTION
The original code pushes the extracted claims into the HTTP 'out' headers, however, the original use case is to pass these claims as a header by reverse proxying. These headers are contained in the 'in' headers. This commit repairs the issue.

The code as in master returns the extracted claims to the calling party not the proxied application.