### PR TITLE
Fix: Only call `docker rmi` if there are images to prune

### DIFF
--- a/scripts.sh
+++ b/scripts.sh
@@ -40,7 +40,10 @@ build_nginx() {
 		printf "${GREEN}✓ Successfully built NGINX module ${NC}"
 	fi
 
-	docker rmi -f $(docker images --filter=label=stage=builder --quiet)
+	images=$(docker images --filter=label=stage=builder --quiet)
+	if [ ! -z "$images" ]; then
+		docker rmi -f $images
+	fi
 }
 
 rebuild_nginx() {

--- a/scripts.sh
+++ b/scripts.sh
@@ -40,10 +40,7 @@ build_nginx() {
 		printf "${GREEN}✓ Successfully built NGINX module ${NC}"
 	fi
 
-	images=$(docker images --filter=label=stage=builder --quiet)
-	if [ ! -z "$images" ]; then
-		docker rmi -f $images
-	fi
+	docker rmi -f $(docker images --filter=label=stage=builder --quiet) || true
 }
 
 rebuild_nginx() {


### PR DESCRIPTION
This PR modifies the build script so that `docker rmi` is only being called if the `docker images --filter=label=stage=builder --quiet` returns images at all.

This is important for CI environments because otherwise the build step would fail