### PR TITLE
rename `auth_jwt_authorization_type` to `auth_jwt_location` and support pulling JWT from any header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ MAJ=$(echo ${NGINX_VERSION} | cut -f1 -d.)
 MIN=$(echo ${NGINX_VERSION} | cut -f2 -d.)
 REV=$(echo ${NGINX_VERSION} | cut -f3 -d.)
 
-# NGINX 1.23.0+ changes `cookies` to `cookie` 
+# NGINX 1.23.0+ changes cookies to use a linked list, and renames `cookies` to `cookie`
 if [ "${MAJ}" -gt 1 ] || [ "${MAJ}" -eq 1 -a "${MIN}" -ge 23 ]; then
 	BUILD_FLAGS="${BUILD_FLAGS} --with-cc-opt='-DNGX_LINKED_LIST_COOKIES=1'"
 fi

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This module requires several new `nginx.conf` directives, which can be specified
 | `auth_jwt_loginurl`                  | The URL to redirect to if `auth_jwt_redirect` is enabled and authentication fails.                                                                   |
 | `auth_jwt_enabled`                   | Set to "on" to enable JWT checking.                                                                                                                  |
 | `auth_jwt_algorithm`                 | The algorithm to use. One of: HS256, HS384, HS512, RS256, RS384, RS512                                                                               |
-| `auth_jwt_validation_type`           | Indicates where the JWT is located in the request -- see below.                                                                                      |
+| `auth_jwt_location`                  | Indicates where the JWT is located in the request -- see below.                                                                                      |
 | `auth_jwt_validate_sub`              | Set to "on" to validate the `sub` claim (e.g. user id) in the JWT.                                                                                   |
 | `auth_jwt_extract_request_claims`    | Set to a space-delimited list of claims to extract from the JWT and set as request headers. These will be accessible via e.g: `$http_jwt_sub`        |
 | `auth_jwt_extract_response_claims`   | Set to a space-delimited list of claims to extract from the JWT and set as response headers. These will be accessible via e.g: `$sent_http_jwt_sub`  |
@@ -67,10 +67,11 @@ auth_jwt_redirect off;
 ```
 ## JWT Locations
 
-By default, the authorization header is used to provide a JWT for validation. However, you may use the `auth_jwt_validation_type` configuration to specify the name of a cookie that provides the JWT:
+By default, the`Authorization` header is used to provide a JWT for validation. However, you may use the `auth_jwt_location` directive to specify the name of the header or cookie which provides the JWT:
 
 ```nginx
-auth_jwt_validation_type COOKIE=jwt;
+auth_jwt_location HEADER=auth-token;  # get the JWT from the "auth-token" header
+auth_jwt_location COOKIE=auth-token;  # get the JWT from the "auth-token" cookie
 ```
 
 ## `sub` Validation

--- a/test/etc/nginx/conf.d/test.conf
+++ b/test/etc/nginx/conf.d/test.conf
@@ -17,7 +17,7 @@ server {
     location /secure/cookie/default {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type COOKIE=jwt;
+        auth_jwt_location COOKIE=jwt;
         
         alias /usr/share/nginx/html/;
         try_files index.html =404;
@@ -27,7 +27,7 @@ server {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
         auth_jwt_validate_sub on;
-        auth_jwt_validation_type COOKIE=jwt;
+        auth_jwt_location COOKIE=jwt;
         
         alias /usr/share/nginx/html/;
         try_files index.html =404;
@@ -36,7 +36,7 @@ server {
     location /secure/cookie/default/no-redirect {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type COOKIE=jwt;
+        auth_jwt_location COOKIE=jwt;
 
         alias /usr/share/nginx/html/;
         try_files index.html =404;
@@ -45,7 +45,7 @@ server {
     location /secure/cookie/hs256 {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type COOKIE=jwt;
+        auth_jwt_location COOKIE=jwt;
         auth_jwt_algorithm HS256;
 
         alias /usr/share/nginx/html/;
@@ -55,7 +55,7 @@ server {
     location /secure/cookie/hs384 {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type COOKIE=jwt;
+        auth_jwt_location COOKIE=jwt;
         auth_jwt_algorithm HS384;
 
         alias /usr/share/nginx/html/;
@@ -65,7 +65,7 @@ server {
     location /secure/cookie/hs512 {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type COOKIE=jwt;
+        auth_jwt_location COOKIE=jwt;
         auth_jwt_algorithm HS512;
 
         alias /usr/share/nginx/html/;
@@ -75,7 +75,7 @@ server {
     location /secure/auth-header/default {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
 
         alias /usr/share/nginx/html/;
         try_files index.html =404;
@@ -84,7 +84,7 @@ server {
     location /secure/auth-header/default/no-redirect {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
 
         alias /usr/share/nginx/html/;
         try_files index.html =404;
@@ -93,7 +93,7 @@ server {
     location /secure/auth-header/rs256 {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_key "-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwtpMAM4l1H995oqlqdMh
 uqNuffp4+4aUCwuFE9B5s9MJr63gyf8jW0oDr7Mb1Xb8y9iGkWfhouZqNJbMFry+
@@ -111,7 +111,7 @@ BwIDAQAB
     location /secure/auth-header/rs256/file {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_algorithm RS256;
         auth_jwt_use_keyfile on;
         auth_jwt_keyfile_path "/etc/nginx/rsa-key.conf";
@@ -123,7 +123,7 @@ BwIDAQAB
     location /secure/auth-header/rs384/file {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_algorithm RS384;
         auth_jwt_use_keyfile on;
         auth_jwt_keyfile_path "/etc/nginx/rsa-key.conf";
@@ -135,7 +135,7 @@ BwIDAQAB
     location /secure/auth-header/rs512/file {
         auth_jwt_enabled on;
         auth_jwt_redirect on;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_algorithm RS512;
         auth_jwt_use_keyfile on;
         auth_jwt_keyfile_path "/etc/nginx/rsa-key.conf";
@@ -144,10 +144,20 @@ BwIDAQAB
         try_files index.html =404;
     }
 
+    location /secure/custom-header/hs256 {
+        auth_jwt_enabled on;
+        auth_jwt_redirect on;
+        auth_jwt_location HEADER=Auth-Token;
+        auth_jwt_algorithm HS256;
+
+        alias /usr/share/nginx/html/;
+        try_files index.html =404;
+    }
+
     location /secure/extract-claim/request/sub {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_request_claims sub;
 
         add_header "Test" "sub=$http_jwt_sub";
@@ -159,7 +169,7 @@ BwIDAQAB
     location /secure/extract-claim/request/name-1 {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_request_claims firstName lastName;
 
         add_header "Test" "$http_jwt_firstname $http_jwt_lastname";
@@ -171,7 +181,7 @@ BwIDAQAB
     location /secure/extract-claim/request/name-2 {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_request_claims firstName;
         auth_jwt_extract_request_claims lastName;
 
@@ -184,7 +194,7 @@ BwIDAQAB
     location /secure/extract-claim/response/sub {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_response_claims sub;
 
         add_header "Test" "sub=$sent_http_jwt_sub";
@@ -196,7 +206,7 @@ BwIDAQAB
     location /secure/extract-claim/response/name-1 {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_response_claims firstName lastName;
 
         add_header "Test" "$sent_http_jwt_firstname $sent_http_jwt_lastname";
@@ -208,7 +218,7 @@ BwIDAQAB
     location /secure/extract-claim/response/name-2 {
         auth_jwt_enabled on;
         auth_jwt_redirect off;
-        auth_jwt_validation_type AUTHORIZATION;
+        auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_response_claims firstName;
         auth_jwt_extract_response_claims lastName;
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -109,10 +109,15 @@ main() {
            -p '/secure/auth-header/default' \
            -c '302'
 
-  run_test -n 'when auth enabled with default algorithm with no redirect and Authorization header missing Bearer, should return 401' \
+  run_test -n 'when auth enabled with default algorithm with no redirect and Authorization header missing Bearer, should return 200' \
            -p '/secure/auth-header/default/no-redirect' \
-           -c '401' \
-           -x '--header "Authorization: X"'
+           -c '200' \
+           -x "--header \"Authorization: ${JWT_HS256_VALID}\""
+
+  run_test -n 'when auth enabled with default algorithm with no redirect and Authorization header with Bearer, should return 200' \
+           -p '/secure/auth-header/default/no-redirect' \
+           -c '200' \
+           -x "--header \"Authorization: Bearer ${JWT_HS256_VALID}\""
 
   run_test -n 'when auth enabled with default algorithm and no JWT cookie, returns 302' \
            -p '/secure/cookie/default' \
@@ -143,7 +148,7 @@ main() {
            -x ' --cookie "jwt=${JWT_HS256_MISSING_EMAIL}"'
 
   run_test -n 'when auth enabled with HS256 algorithm and valid JWT cookie, returns 200' \
-           -p '/secure/cookie/hs256/' \
+           -p '/secure/cookie/hs256' \
            -c '200' \
            -x '--cookie "jwt=${JWT_HS256_VALID}"'
 
@@ -181,6 +186,16 @@ main() {
            -p '/secure/auth-header/rs512/file' \
            -c '200' \
            -x '--header "Authorization: Bearer ${JWT_RS256_VALID}"'
+
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT in custom header without bearer, returns 200' \
+           -p '/secure/custom-header/hs256/' \
+           -c '200' \
+           -x '--header "Auth-Token: ${JWT_HS256_VALID}"'
+
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT in custom header with bearer, returns 200' \
+           -p '/secure/custom-header/hs256/' \
+           -c '200' \
+           -x '--header "Auth-Token: Bearer ${JWT_HS256_VALID}"'
 
   run_test -n 'extracts single claim to request header' \
            -p '/secure/extract-claim/request/sub' \


### PR DESCRIPTION
Fixed #79.

- renamed `auth_jwt_authorization_type` to `auth_jwt_location`
- added support for pulling JWT from any header