### PR TITLE
fix extraction of claims in nested config block

### DIFF
--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 ngx_module_type=HTTP
 ngx_addon_name=ngx_http_auth_jwt_module
 ngx_module_name=$ngx_addon_name
-ngx_module_srcs="${ngx_addon_dir}/src/ngx_http_auth_jwt_binary_converters.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_header_processing.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_string.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_module.c"
+ngx_module_srcs="${ngx_addon_dir}/src/arrays.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_binary_converters.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_header_processing.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_string.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_module.c"
 ngx_module_libs="-ljansson -ljwt -lm"
 
 . auto/module

--- a/src/arrays.c
+++ b/src/arrays.c
@@ -1,0 +1,14 @@
+#include "arrays.h"
+#include <ngx_core.h>
+
+void merge_array(ngx_pool_t *pool, ngx_array_t **dest, const ngx_array_t *src, size_t size)
+{
+  // only merge if dest is non-null and src is null
+  if (src != NULL && *dest == NULL)
+  {
+    *dest = ngx_array_create(pool, src->nelts, size);
+
+    ngx_memcpy((*dest)->elts, src->elts, src->nelts * size);
+    (*dest)->nelts = src->nelts;
+  }
+}

--- a/src/arrays.h
+++ b/src/arrays.h
@@ -1,0 +1,7 @@
+#ifndef _ARRAYS_H
+#define _ARRAYS_H
+#include <ngx_core.h>
+
+void merge_array(ngx_pool_t *pool, ngx_array_t **dest, const ngx_array_t *src, size_t size);
+
+#endif

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -14,6 +14,7 @@
 
 #include <jansson.h>
 
+#include "arrays.h"
 #include "ngx_http_auth_jwt_header_processing.h"
 #include "ngx_http_auth_jwt_binary_converters.h"
 #include "ngx_http_auth_jwt_string.h"
@@ -212,8 +213,8 @@ static char *merge_conf(ngx_conf_t *cf, void *parent, void *child)
   ngx_conf_merge_str_value(conf->algorithm, prev->algorithm, "HS256");
   ngx_conf_merge_str_value(conf->keyfile_path, prev->keyfile_path, "");
   ngx_conf_merge_off_value(conf->validate_sub, prev->validate_sub, 0);
-  ngx_conf_merge_ptr_value(conf->extract_request_claims, prev->extract_request_claims, NULL);
-  ngx_conf_merge_ptr_value(conf->extract_request_claims, prev->extract_response_claims, NULL);
+  merge_array(cf->pool, &conf->extract_request_claims, prev->extract_request_claims, sizeof(ngx_str_t));
+  merge_array(cf->pool, &conf->extract_response_claims, prev->extract_response_claims, sizeof(ngx_str_t));
 
   if (conf->enabled == NGX_CONF_UNSET)
   {

--- a/test/etc/nginx/conf.d/test.conf
+++ b/test/etc/nginx/conf.d/test.conf
@@ -172,7 +172,7 @@ BwIDAQAB
         auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_request_claims firstName lastName;
 
-        add_header "Test" "$http_jwt_firstname $http_jwt_lastname";
+        add_header "Test" "firstName=$http_jwt_firstname; lastName=$http_jwt_lastname";
 
         alias /usr/share/nginx/html/;
         try_files index.html =404;
@@ -185,10 +185,24 @@ BwIDAQAB
         auth_jwt_extract_request_claims firstName;
         auth_jwt_extract_request_claims lastName;
 
-        add_header "Test" "$http_jwt_firstname $http_jwt_lastname";
+        add_header "Test" "firstName=$http_jwt_firstname; lastName=$http_jwt_lastname";
 
         alias /usr/share/nginx/html/;
         try_files index.html =404;
+    }
+
+    location /secure/extract-claim/request/nested {
+        location /secure/extract-claim/request/nested {
+            auth_jwt_enabled on;
+            auth_jwt_redirect off;
+            auth_jwt_location HEADER=Authorization;
+            auth_jwt_extract_request_claims username;
+
+            add_header "Test" "username=$http_jwt_username";
+
+            alias /usr/share/nginx/html/;
+            try_files index.html =404;
+        }
     }
 
     location /secure/extract-claim/response/sub {
@@ -209,7 +223,7 @@ BwIDAQAB
         auth_jwt_location HEADER=Authorization;
         auth_jwt_extract_response_claims firstName lastName;
 
-        add_header "Test" "$sent_http_jwt_firstname $sent_http_jwt_lastname";
+        add_header "Test" "firstName=$sent_http_jwt_firstname; lastName=$sent_http_jwt_lastname";
 
         alias /usr/share/nginx/html/;
         try_files index.html =404;
@@ -222,10 +236,24 @@ BwIDAQAB
         auth_jwt_extract_response_claims firstName;
         auth_jwt_extract_response_claims lastName;
 
-        add_header "Test" "$sent_http_jwt_firstname $sent_http_jwt_lastname";
+        add_header "Test" "firstName=$sent_http_jwt_firstname; lastName=$sent_http_jwt_lastname";
 
         alias /usr/share/nginx/html/;
         try_files index.html =404;
+    }
+
+    location /secure/extract-claim/response/nested {
+        location /secure/extract-claim/response/nested {
+            auth_jwt_enabled on;
+            auth_jwt_redirect off;
+            auth_jwt_location HEADER=Authorization;
+            auth_jwt_extract_response_claims username;
+
+            add_header "Test" "username=$sent_http_jwt_username";
+
+            alias /usr/share/nginx/html/;
+            try_files index.html =404;
+        }
     }
 }
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -56,7 +56,7 @@ run_test () {
       printf "${RED}${name} -- unexpected exit code from cURL\n\tcURL Exit Code: ${exitCode}";
       NUM_FAILED=$((${NUM_FAILED} + 1));
     else
-      OKAY=1
+      local okay=1
 
       if [ "${expectedCode}" != "" ]; then
         local responseCode=$(echo "${response}" | grep -Eo 'HTTP/1.1 ([0-9]{3})' | awk '{print $2}')
@@ -64,17 +64,17 @@ run_test () {
         if [ "${expectedCode}" != "${responseCode}" ]; then
           printf "${RED}${name} -- unexpected status code\n\tExpected: ${expectedCode}\n\tActual: ${responseCode}\n\tPath: ${path}"
           NUM_FAILED=$((${NUM_FAILED} + 1))
-          OKAY=0
+          okay=0
         fi
       fi
-
-      if [ "${OKAY}" == "1" ] && [ "${expectedResponseRegex}" != "" ] && echo "${response}" | grep -Eq "${expectedResponseRegex}"; then
+      
+      if [ "${okay}" == '1' ] && [ "${expectedResponseRegex}" != "" ] && ! [[ "${response}" =~ "${expectedResponseRegex}" ]]; then
         printf "${RED}${name} -- regex not found in response\n\tPath: ${path}\n\tRegEx: ${expectedResponseRegex}"
         NUM_FAILED=$((${NUM_FAILED} + 1))
-        OKAY=0
+        okay=0
       fi
       
-      if [ "${OKAY}" == "1" ]; then
+      if [ "${okay}" == '1' ]; then
         printf "${GREEN}${name}";
       fi
     fi
@@ -197,34 +197,64 @@ main() {
            -c '200' \
            -x '--header "Auth-Token: Bearer ${JWT_HS256_VALID}"'
 
-  run_test -n 'extracts single claim to request header' \
+  run_test -n 'extracts single claim to request variable' \
            -p '/secure/extract-claim/request/sub' \
-           -r '^Test: sub=some-long-uuid$' \
+           -r '< Test: sub=some-long-uuid' \
            -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
 
-  run_test -n 'extracts multiple claims (single directive) to request header' \
+  run_test -n 'extracts multiple claims (single directive) to request variable' \
            -p '/secure/extract-claim/request/name-1' \
-           -r '^Test: hello world$' \
+           -r '< Test: firstName=hello; lastName=world' \
            -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
 
-  run_test -n 'extracts multiple claims (multiple directives) to request header' \
+  run_test -n 'extracts multiple claims (multiple directives) to request variable' \
            -p '/secure/extract-claim/request/name-2' \
-           -r '^Test: hello world$' \
+           -r '< Test: firstName=hello; lastName=world' \
+           -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
+
+  run_test -n 'extracts nested claim to request variable' \
+           -p '/secure/extract-claim/request/nested' \
+           -r '< Test: username=hello.world' \
+           -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
+
+  run_test -n 'extracts single claim to response variable' \
+           -p '/secure/extract-claim/response/sub' \
+           -r '< Test: sub=some-long-uuid' \
+           -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
+
+  run_test -n 'extracts multiple claims (single directive) to response variable' \
+           -p '/secure/extract-claim/response/name-1' \
+           -r '< Test: firstName=hello; lastName=world' \
+           -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
+
+  run_test -n 'extracts multiple claims (multiple directives) to response variable' \
+           -p '/secure/extract-claim/response/name-2' \
+           -r '< Test: firstName=hello; lastName=world' \
+           -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
+
+  run_test -n 'extracts nested claim to response variable' \
+           -p '/secure/extract-claim/response/nested' \
+           -r '< Test: username=hello.world' \
            -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
 
   run_test -n 'extracts single claim to response header' \
            -p '/secure/extract-claim/response/sub' \
-           -r '^Test: sub=some-long-uuid$' \
+           -r '< JWT-sub: some-long-uuid' \
            -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
 
   run_test -n 'extracts multiple claims (single directive) to response header' \
            -p '/secure/extract-claim/response/name-1' \
-           -r '^Test: hello world$' \
+           -r '< JWT-firstName: hello' \
            -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
 
   run_test -n 'extracts multiple claims (multiple directives) to response header' \
            -p '/secure/extract-claim/response/name-2' \
-           -r '^Test: hello world$' \
+           -r '< JWT-firstName: hello' \
+           -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
+
+  run_test -n 'extracts nested claim to response header' \
+           -p '/secure/extract-claim/response/nested' \
+           -r '< JWT-username: hello.world' \
            -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
 
   if [[ "${NUM_FAILED}" = '0' ]]; then


### PR DESCRIPTION
Claims extracted at a higher level in the config tree were not being passed down to lower levels.

Also fixed the response-checking portion of the tests.