### PR TITLE
get token from querystring funcionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ auth_jwt_redirect off;
 ```
 ## JWT Locations
 
-By default, the`Authorization` header is used to provide a JWT for validation. However, you may use the `auth_jwt_location` directive to specify the name of the header or cookie which provides the JWT:
+By default, the`Authorization` header is used to provide a JWT for validation. However, you may use the `auth_jwt_location` directive to specify the name of the header, cookie or queryString which provides the JWT:
+the Querystring name must be "token".
 
 ```nginx
 auth_jwt_location HEADER=auth-token;  # get the JWT from the "auth-token" header
 auth_jwt_location COOKIE=auth-token;  # get the JWT from the "auth-token" cookie
+auth_jwt_location QUERYSTRING=token;  # get the JWT from the "token" query string
 ```
 
 ## `sub` Validation


### PR DESCRIPTION
Implementation of a new location of the jwt. Querystring location. I'm doing that because of school project where i'm integratin grafana inside my cloud aplication. I open grafana inside an iframe and this is why i need the token in the URL of nginx reverse proxy. I wish that works for you and i'll be happy for a review. Regards from spain. 