### PR TITLE
Feature/support token in query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ By default, the`Authorization` header is used to provide a JWT for validation. H
 ```nginx
 auth_jwt_location HEADER=auth-token;  # get the JWT from the "auth-token" header
 auth_jwt_location COOKIE=auth-token;  # get the JWT from the "auth-token" cookie
+auth_jwt_location QUERY_STRING=jwt-token;   # get the JWT from the "jwt-token" query-string
 ```
+
+Note: If you use the QUERY_STRING location, the given key is stripped from the outgoing request, if the request is to be forwarded.
 
 ## `sub` Validation
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ By default, the`Authorization` header is used to provide a JWT for validation. H
 ```nginx
 auth_jwt_location HEADER=auth-token;  # get the JWT from the "auth-token" header
 auth_jwt_location COOKIE=auth-token;  # get the JWT from the "auth-token" cookie
-auth_jwt_location QUERY_STRING=jwt-token;   # get the JWT from the "jwt-token" query-string
+auth_jwt_location QUERYSTRING=token;   # get the JWT from the "token" querystring parameter
 ```
 
 Note: If you use the QUERY_STRING location, the given key is stripped from the outgoing request, if the request is to be forwarded.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ auth_jwt_location COOKIE=auth-token;  # get the JWT from the "auth-token" cookie
 auth_jwt_location QUERYSTRING=token;   # get the JWT from the "token" querystring parameter
 ```
 
-Note: If you use the QUERY_STRING location, the given key is stripped from the outgoing request, if the request is to be forwarded.
+### Querystring Location
+If you use the `QUERYSTRING` location, the given querystring parameter is stripped from the outgoing request, if the request is to be forwarded. Please also note that including a JWT in the querystring may be a security risk as the JWT could be logged/viewed by intermediary devices/software. In most cases it is best to store the JWT in a header.
 
 ## `sub` Validation
 

--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 ngx_module_type=HTTP
 ngx_addon_name=ngx_http_auth_jwt_module
 ngx_module_name=$ngx_addon_name
-ngx_module_srcs="${ngx_addon_dir}/src/arrays.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_binary_converters.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_header_processing.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_string.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_module.c"
+ngx_module_srcs="${ngx_addon_dir}/src/arrays.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_args_processing.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_binary_converters.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_header_processing.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_string.c ${ngx_addon_dir}/src/ngx_http_auth_jwt_module.c"
 ngx_module_libs="-ljansson -ljwt -lm"
 
 . auto/module

--- a/src/ngx_http_auth_jwt_args_processing.c
+++ b/src/ngx_http_auth_jwt_args_processing.c
@@ -1,5 +1,8 @@
 #include "ngx_http_auth_jwt_args_processing.h"
 
+/* Creates a new version of args without token present.
+ *  Writes length of new args to `*write_args_len`.
+ */
 u_char *create_args_without_token(
     ngx_pool_t *pool,
     ngx_str_t *args,
@@ -7,27 +10,28 @@ u_char *create_args_without_token(
     size_t token_end,
     size_t *write_args_len
 ) {
-  /* Creates a new version of args without token present.
-     Writes length of new args to *write_args_len
-   */
   *write_args_len = args->len - token_end + token_key_start;
-
   u_char *args_ptr = ngx_palloc(pool, *write_args_len);
   
-  if (args_ptr == NULL) return NULL;
-
-  if (token_key_start > 0) {
-    ngx_memcpy(args_ptr, args->data, token_key_start);
+  if (args_ptr == NULL)
+  {
+    return NULL;
   }
-  if (token_end < (args->len - 1)) {
-    ngx_memcpy(
-      args_ptr + token_key_start,
-      args->data + token_end,
-      *write_args_len - token_key_start
-    );
+  else
+  {
+    if (token_key_start > 0) {
+      ngx_memcpy(args_ptr, args->data, token_key_start);
+    }
+    if (token_end < (args->len - 1)) {
+      ngx_memcpy(
+        args_ptr + token_key_start,
+        args->data + token_end,
+        *write_args_len - token_key_start
+      );
+    }
+  
+    return args_ptr;
   }
-
-  return args_ptr;
 }
 
 bool search_token_from_args(

--- a/src/ngx_http_auth_jwt_args_processing.c
+++ b/src/ngx_http_auth_jwt_args_processing.c
@@ -1,0 +1,73 @@
+#include "ngx_http_auth_jwt_args_processing.h"
+
+u_char *create_args_without_token(
+    ngx_pool_t *pool,
+    ngx_str_t *args,
+    size_t token_key_start,
+    size_t token_end,
+    size_t *write_args_len
+) {
+  /* Creates a new version of args without token present.
+     Writes length of new args to *write_args_len
+   */
+  *write_args_len = args->len - token_end + token_key_start;
+
+  u_char *args_ptr = ngx_palloc(pool, *write_args_len);
+  
+  if (args_ptr == NULL) return NULL;
+
+  if (token_key_start > 0) {
+    ngx_memcpy(args_ptr, args->data, token_key_start);
+  }
+  if (token_end < (args->len - 1)) {
+    ngx_memcpy(
+      args_ptr + token_key_start,
+      args->data + token_end,
+      *write_args_len - token_key_start
+    );
+  }
+
+  return args_ptr;
+}
+
+bool search_token_from_args(
+    const ngx_str_t *jwt_location,
+    const ngx_str_t *args,
+    size_t *write_to_token_key_start,
+    size_t *write_to_token_value_start,
+    size_t *write_to_token_end
+) {
+  /* Tries to extract token from query string. Returns true if found, false otherwise.
+     
+     Searches for the string contained in *jwt_location in *args. If it finds the token
+     in question it writes the location of the start of key to *write_to_token_key_start, 
+     start of token itself to *write_to_token_value_start and end of token to *write_to_token_end.
+   */
+  size_t i = 0, j = 0;
+  size_t max_i = args->len > jwt_location->len ? args->len - jwt_location->len : 0;
+
+  while (i < max_i) {
+    j = 0;
+    if (i == 0 || *(args->data + i - 1) == '&') {
+      while (j < jwt_location->len && *(args->data + i + j) == *(jwt_location->data + j)) {
+        if (j == (jwt_location->len - 1)) {
+          *write_to_token_key_start = i;
+          i++;
+          if (i >= max_i || *(args->data + i + j) != '=') {
+            // key doesn't match
+            break;
+          }
+          *write_to_token_value_start = i + j + 1;
+          while (i < args->len && *(args->data + i) != '&') {
+            i++;
+          }
+          *write_to_token_end = i;
+          return true;
+        }
+        j++;
+      }
+    }
+    i++;
+  }
+  return false;
+}

--- a/src/ngx_http_auth_jwt_args_processing.c
+++ b/src/ngx_http_auth_jwt_args_processing.c
@@ -34,6 +34,12 @@ u_char *create_args_without_token(
   }
 }
 
+/* Tries to extract token from query string. Returns true if found, false otherwise.
+     
+  Searches for the string contained in *jwt_location in *args. If it finds the token
+  in question it writes the location of the start of key to *write_to_token_key_start, 
+  start of token itself to *write_to_token_value_start and end of token to *write_to_token_end.
+*/
 bool search_token_from_args(
     const ngx_str_t *jwt_location,
     const ngx_str_t *args,
@@ -41,28 +47,28 @@ bool search_token_from_args(
     size_t *write_to_token_value_start,
     size_t *write_to_token_end
 ) {
-  /* Tries to extract token from query string. Returns true if found, false otherwise.
-     
-     Searches for the string contained in *jwt_location in *args. If it finds the token
-     in question it writes the location of the start of key to *write_to_token_key_start, 
-     start of token itself to *write_to_token_value_start and end of token to *write_to_token_end.
-   */
   size_t i = 0, j = 0;
   size_t max_i = args->len > jwt_location->len ? args->len - jwt_location->len : 0;
 
-  while (i < max_i) {
+  while (i < max_i) 
+  {
     j = 0;
-    if (i == 0 || *(args->data + i - 1) == '&') {
-      while (j < jwt_location->len && *(args->data + i + j) == *(jwt_location->data + j)) {
-        if (j == (jwt_location->len - 1)) {
+    if (i == 0 || *(args->data + i - 1) == '&')
+    {
+      while (j < jwt_location->len && *(args->data + i + j) == *(jwt_location->data + j))
+      {
+        if (j == (jwt_location->len - 1))
+        {
           *write_to_token_key_start = i;
           i++;
-          if (i >= max_i || *(args->data + i + j) != '=') {
+          if (i >= max_i || *(args->data + i + j) != '=')
+          {
             // key doesn't match
             break;
           }
           *write_to_token_value_start = i + j + 1;
-          while (i < args->len && *(args->data + i) != '&') {
+          while (i < args->len && *(args->data + i) != '&')
+          {
             i++;
           }
           *write_to_token_end = i;

--- a/src/ngx_http_auth_jwt_args_processing.h
+++ b/src/ngx_http_auth_jwt_args_processing.h
@@ -1,0 +1,23 @@
+#ifndef _NGX_HTTP_AUTH_JWT_ARGS_PROCESSING_H
+#define _NGX_HTTP_AUTH_JWT_ARGS_PROCESSING_H
+
+#include <ngx_core.h>
+#include <stdbool.h>
+
+u_char *create_args_without_token(
+    ngx_pool_t *pool,
+    ngx_str_t *args,
+    size_t token_key_start,
+    size_t token_end,
+    size_t *write_mutated_args_len
+);
+
+bool search_token_from_args(
+    const ngx_str_t *jwt_location,
+    const ngx_str_t *args,
+    size_t *write_to_token_key_start,
+    size_t *write_to_token_value_start,
+    size_t *write_to_token_end
+);
+
+#endif /* _NGX_HTTP_AUTH_JWT_ARGS_PROCESSING_H */

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -15,6 +15,7 @@
 #include <jansson.h>
 
 #include "arrays.h"
+#include "ngx_http_auth_jwt_args_processing.h"
 #include "ngx_http_auth_jwt_header_processing.h"
 #include "ngx_http_auth_jwt_binary_converters.h"
 #include "ngx_http_auth_jwt_string.h"
@@ -613,6 +614,7 @@ static char *get_jwt(ngx_http_request_t *r, ngx_str_t jwt_location)
 {
   static const char *HEADER_PREFIX = "HEADER=";
   static const char *COOKIE_PREFIX = "COOKIE=";
+  static const char QUERY_STRING_PREFIX[] = "QUERY_STRING=";
   char *jwtPtr = NULL;
 
   ngx_log_debug(NGX_LOG_DEBUG, r->connection->log, 0, "jwt_location.len %d", jwt_location.len);
@@ -670,6 +672,55 @@ static char *get_jwt(ngx_http_request_t *r, ngx_str_t jwt_location)
       jwtPtr = ngx_str_t_to_char_ptr(r->pool, jwtCookieVal);
     }
   }
+  else if (jwt_location.len > sizeof(QUERY_STRING_PREFIX) && ngx_strncmp(jwt_location.data, QUERY_STRING_PREFIX, sizeof(QUERY_STRING_PREFIX) - 1) == 0) {
+    jwt_location.data += sizeof(QUERY_STRING_PREFIX) - 1;
+    jwt_location.len -= sizeof(QUERY_STRING_PREFIX) - 1;
 
+    size_t token_key_start = 0, token_value_start = 0, token_end = 0;
+
+    bool found_token = search_token_from_args(
+      &jwt_location,
+      &r->args,
+      &token_key_start,
+      &token_value_start,
+      &token_end
+    );
+
+    if (!found_token) return NULL;
+
+    int token_len = token_end - token_value_start;
+
+    jwtPtr = ngx_palloc(r->pool, token_len + 1);
+    if (jwtPtr != NULL) {
+      ngx_memcpy(jwtPtr, r->args.data + token_value_start, token_len);
+      *(jwtPtr + token_len) = '\0';
+    }
+
+    // strip first or last & from args
+    if (token_key_start > 0) {
+      token_key_start--;
+    } else if (token_end < (r->args.len - 1)) {
+      token_end++;
+    }
+
+    size_t mutated_args_len = 0;
+
+    // Strip key from args
+    u_char *args_ptr = create_args_without_token(
+      r->pool,
+      &r->args,
+      token_key_start,
+      token_end,
+      &mutated_args_len
+    );
+
+    if (args_ptr == NULL) return jwtPtr;
+
+    int free_ok = ngx_pfree(r->pool, r->args.data);
+    if (free_ok == NGX_OK) {
+      r->args.data = args_ptr;
+      r->args.len = mutated_args_len;
+    }
+  }
   return jwtPtr;
 }

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -719,11 +719,8 @@ static char *get_jwt(ngx_http_request_t *r, ngx_str_t jwt_location)
 
       if (args_ptr != NULL)
       {
-        int free_ok = ngx_pfree(r->pool, r->args.data);
-        if (free_ok == NGX_OK) {
-          r->args.data = args_ptr;
-          r->args.len = mutated_args_len;
-        }
+        r->args.data = args_ptr;
+        r->args.len = mutated_args_len;
       }
     }
   }

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -686,10 +686,7 @@ static char *get_jwt(ngx_http_request_t *r, ngx_str_t jwt_location)
       &token_end
     );
 
-    if (!found_token){
-      return NULL;
-    }
-    else
+    if (found_token)
     {
       int token_len = token_end - token_value_start;
 

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -612,8 +612,8 @@ static ngx_int_t load_public_key(ngx_conf_t *cf, auth_jwt_conf_t *conf)
 
 static char *get_jwt(ngx_http_request_t *r, ngx_str_t jwt_location)
 {
-  static const char *HEADER_PREFIX = "HEADER=";
-  static const char *COOKIE_PREFIX = "COOKIE=";
+  static const char HEADER_PREFIX[] = "HEADER=";
+  static const char COOKIE_PREFIX[] = "COOKIE=";
   static const char QUERY_STRING_PREFIX[] = "QUERYSTRING=";
   char *jwtPtr = NULL;
 

--- a/test/etc/nginx/conf.d/test.conf
+++ b/test/etc/nginx/conf.d/test.conf
@@ -165,6 +165,15 @@ BwIDAQAB
         try_files index.html =404;
     }
 
+    location /secure/auth-query-string/hs256 {
+        auth_jwt_enabled on;
+        auth_jwt_location QUERY_STRING=jwt-token;
+        auth_jwt_algorithm HS256;
+
+        alias /usr/share/nginx/html/;
+        try_files index.html =404;
+    }
+
     location /secure/extract-claim/request/sub {
         auth_jwt_enabled on;
         auth_jwt_redirect off;

--- a/test/etc/nginx/conf.d/test.conf
+++ b/test/etc/nginx/conf.d/test.conf
@@ -167,7 +167,7 @@ BwIDAQAB
 
     location /secure/auth-query-string/hs256 {
         auth_jwt_enabled on;
-        auth_jwt_location QUERY_STRING=jwt-token;
+        auth_jwt_location QUERYSTRING=token;
         auth_jwt_algorithm HS256;
 
         alias /usr/share/nginx/html/;

--- a/test/test.sh
+++ b/test/test.sh
@@ -202,6 +202,42 @@ main() {
            -p '/secure/custom-header/hs256/' \
            -c '200' \
            -x '--header "Auth-Token: Bearer ${JWT_HS256_VALID}"'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token, returns 200' \
+           -p '/secure/auth-query-string/hs256/?jwt-token=${JWT_HS256_VALID}' \
+           -c '200'
+
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string something-jwt-token, returns 401' \
+           -p '/secure/auth-query-string/hs256/?something-jwt-token=${JWT_HS256_VALID}' \
+           -c '401'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and non-valid JWT as query-string jwt-token, returns 401' \
+           -p '/secure/auth-query-string/hs256/?jwt-token=ABBAKEY' \
+           -c '401'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and no query-string present, returns 401' \
+           -p '/secure/auth-query-string/hs256/' \
+           -c '401'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and just random query-string present, returns 401' \
+           -p '/secure/auth-query-string/hs256/?key1=abba' \
+           -c '401'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token after first query-string, returns 200' \
+           -p '/secure/auth-query-string/hs256/?key1=abba\&jwt-token=${JWT_HS256_VALID}' \
+           -c '200'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token, second query-string after, returns 200' \
+           -p '/secure/auth-query-string/hs256/?jwt-token=${JWT_HS256_VALID}\&key1=abba' \
+           -c '200'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token in middle, returns 200' \
+           -p '/secure/auth-query-string/hs256/?key1=abba\&jwt-token=${JWT_HS256_VALID}\&key2=abba' \
+           -c '200'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token with overlapping query-string first, returns 200' \
+           -p '/secure/auth-query-string/hs256/?jwt-token2=abba\&jwt-token=${JWT_HS256_VALID}' \
+           -c '200'
 
   run_test -n 'extracts single claim to request variable' \
            -p '/secure/extract-claim/request/sub' \

--- a/test/test.sh
+++ b/test/test.sh
@@ -204,7 +204,7 @@ main() {
            -x '--header "Auth-Token: Bearer ${JWT_HS256_VALID}"'
   
   run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token, returns 200' \
-           -p '/secure/auth-query-string/hs256/?jwt-token=${JWT_HS256_VALID}' \
+           -p '/secure/auth-query-string/hs256/?token=${JWT_HS256_VALID}' \
            -c '200'
 
   run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string something-jwt-token, returns 401' \
@@ -212,11 +212,19 @@ main() {
            -c '401'
   
   run_test -n 'when auth enabled with HS256 algorithm and non-valid JWT as query-string jwt-token, returns 401' \
-           -p '/secure/auth-query-string/hs256/?jwt-token=ABBAKEY' \
+           -p '/secure/auth-query-string/hs256/?token=ABBAKEY' \
            -c '401'
   
   run_test -n 'when auth enabled with HS256 algorithm and no query-string present, returns 401' \
            -p '/secure/auth-query-string/hs256/' \
+           -c '401'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and empty token present, returns 401' \
+           -p '/secure/auth-query-string/hs256/?token' \
+           -c '401'
+  
+  run_test -n 'when auth enabled with HS256 algorithm and empty token present, returns 401' \
+           -p '/secure/auth-query-string/hs256/?token=' \
            -c '401'
   
   run_test -n 'when auth enabled with HS256 algorithm and just random query-string present, returns 401' \
@@ -224,19 +232,19 @@ main() {
            -c '401'
   
   run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token after first query-string, returns 200' \
-           -p '/secure/auth-query-string/hs256/?key1=abba\&jwt-token=${JWT_HS256_VALID}' \
+           -p '/secure/auth-query-string/hs256/?key1=abba\&token=${JWT_HS256_VALID}' \
            -c '200'
   
   run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token, second query-string after, returns 200' \
-           -p '/secure/auth-query-string/hs256/?jwt-token=${JWT_HS256_VALID}\&key1=abba' \
+           -p '/secure/auth-query-string/hs256/?token=${JWT_HS256_VALID}\&key1=abba' \
            -c '200'
   
   run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token in middle, returns 200' \
-           -p '/secure/auth-query-string/hs256/?key1=abba\&jwt-token=${JWT_HS256_VALID}\&key2=abba' \
+           -p '/secure/auth-query-string/hs256/?key1=abba\&token=${JWT_HS256_VALID}\&key2=abba' \
            -c '200'
   
   run_test -n 'when auth enabled with HS256 algorithm and valid JWT as query-string jwt-token with overlapping query-string first, returns 200' \
-           -p '/secure/auth-query-string/hs256/?jwt-token2=abba\&jwt-token=${JWT_HS256_VALID}' \
+           -p '/secure/auth-query-string/hs256/?jwt-token2=abba\&token=${JWT_HS256_VALID}' \
            -c '200'
 
   run_test -n 'extracts single claim to request variable' \


### PR DESCRIPTION
First of all, thanks for a great repository!

This PR adds the possibility to specify the JWT-token to be provided as a query string parameter:
* auth_jwt_location QUERY_STRING=jwt-token defines the token to be provided with the key `jwt-token`
* Given key is stripped from outgoing request
* Adds tests to verify parsing of query-string arguments

I've verified that the key is stripped from the outgoing request manually, but couldn't find a way to add this as an automatic test case in a reasonable amount of time. 

Note that only after forking and creating the modifications, did I encounter a previous PR on the same topic:
https://github.com/TeslaGov/ngx-http-auth-jwt-module/pull/103

The same concerns regarding security of course applies, and I totally agree with that tokens should not be passed in the query string. However, I see use-cases where the trade-off concerning security would be justified. Nginx plus seems to have the same conclusion:
 ```
NGINX Plus can also obtain the JWT from a query string parameter. To configure this, include the token= parameter to the [auth_jwt](https://nginx.org/en/docs/http/ngx_http_auth_jwt_module.html#auth_jwt) directive:
```

My use-case is to create a proxy for providing map-tiles for Leaflet from a 3rd-party tile-provider, who are behind authentication that is done by the proxy. In this case, I also want the clients to authenticate against the proxy. Providing the token in the query-string for the individual tiles greatly simplifies the application, as opposed to providing authentication-headers inside <img> elements.

I also noticed possible bug in
```c
static const char *HEADER_PREFIX = "HEADER=";
static const char *COOKIE_PREFIX = "COOKIE=";
```
as `sizeof` is used for these, which returns the size of the pointer instead of the data?