### PR TITLE
Feature: Add support for ARM64

### DIFF
--- a/openssl.dockerfile
+++ b/openssl.dockerfile
@@ -31,8 +31,8 @@ RUN <<`
     ldconfig
 
     ln -sf ${OUT_DIR}/bin/openssl /usr/bin/openssl
-    ln -sf ${OUT_DIR}/lib64/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
-    ln -sf ${OUT_DIR}/lib64/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+    ln -sf ${OUT_DIR}/lib64/libssl.so.3 /lib/$(uname -m)-linux-gnu/libssl.so.3
+    ln -sf ${OUT_DIR}/lib64/libcrypto.so.3 /lib/$(uname -m)-linux-gnu/libcrypto.so.3
 `
 WORKDIR /
 RUN rm -rf ${SRC_DIR}


### PR DESCRIPTION
This pull request includes changes to Dockerfiles to improve consistency and compatibility across different architectures. The most important change is the modification of the symbolic links in `openssl.dockerfile`.

Changes to `nginx.dockerfile`:

* Standardized the `FROM` statements to use uppercase `AS` for consistency. (`nginx.dockerfile`, [nginx.dockerfileL5-R13](diffhunk://#diff-bd2119a58663f95e0ffc61444a432f5b369a7f6b77788cd1debacf62f0a05115L5-R13))

Changes to `openssl.dockerfile`:

* Updated symbolic links to use `$(uname -m)` for better compatibility across different system architectures. (`openssl.dockerfile`, [openssl.dockerfileL33-R34](diffhunk://#diff-5754b465073671baca6bf9ed510d422ac63dfe082b0ba6c3ce3cdf1430e556e0L33-R34))

Credit to @Ner0ls for coming up with the idea.