### PR TITLE
Fix read of uninitialized data

### DIFF
--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -355,7 +355,7 @@ static ngx_int_t get_jwt_var_claim(ngx_http_request_t *r, ngx_http_variable_valu
 
   ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "getting jwt var claim for var at index %l", *claim_idx);
 
-  if (ctx == NULL)
+  if (ctx == NULL || ctx->validation_status != NGX_OK)
   {
     ngx_log_debug(NGX_LOG_DEBUG_HTTP, r->connection->log, 0, "no module context found while getting jwt value");
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -341,8 +341,13 @@ main() {
            -c 200 \
            -r 'sub: some-long-uuid$' \
            -x '--header "Authorization: Bearer ${JWT_HS256_VALID}"'
+  
+  run_test -n 'fails gracefully when extracting single claim as var with no JWT, auth jwt enabled' \
+           -p '/secure/extract-claim/body/sub' \
+           -c 200 \
+           -r 'sub: '
 
-  run_test -n 'fails gracefully when extracting single claim as var with no JWT' \
+  run_test -n 'fails gracefully when extracting single claim as var with no JWT, auth jwt disbaled' \
            -p '/unsecure/extract-claim/body/sub' \
            -c 200 \
            -r 'sub: '


### PR DESCRIPTION
`get_jwt_var_claim` had this issue where it would have NINGX return garbage data in var claims to the client due to `ctx` having some of it's objects being uninitialized after the call to  `get_request_jwt_ctx`. The issue was reproducible from making calls while `auth_jwt_enabled` was set to on and the request not having a JWT. Now instead the request will fail gracefully as is expected when there is no JWT in the request.