### PR TITLE
Add compatibility for nginx >= 1.29.6

### DIFF
--- a/.github/workflows/make-releases.yml
+++ b/.github/workflows/make-releases.yml
@@ -106,10 +106,6 @@ jobs:
         MIN=$(echo ${{matrix.nginx-version}} | cut -f2 -d.)
         REV=$(echo ${{matrix.nginx-version}} | cut -f3 -d.)
         
-        if [ "${MAJ}" -gt 1 ] || [ "${MAJ}" -eq 1 -a "${MIN}" -ge 23 ]; then
-          BUILD_FLAGS="${BUILD_FLAGS} --with-cc-opt='-DNGX_LINKED_LIST_COOKIES=1'"
-        fi
-        
         ./configure --with-compat --without-http_rewrite_module --add-dynamic-module=../ngx-http-auth-jwt-module ${BUILD_FLAGS}
 
     - name: Make Modules

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -56,11 +56,6 @@ RUN <<`
 	MIN=$(echo ${NGINX_VERSION} | cut -f2 -d.)
 	REV=$(echo ${NGINX_VERSION} | cut -f3 -d.)
 
-	# NGINX 1.23.0+ changes cookies to use a linked list, and renames `cookies` to `cookie`
-	if [ "${MAJ}" -gt 1 ] || [ "${MAJ}" -eq 1 -a "${MIN}" -ge 23 ]; then
-		BUILD_FLAGS="${BUILD_FLAGS} --with-cc-opt='-DNGX_LINKED_LIST_COOKIES=1'"
-	fi
-
 	./configure \
     --prefix=/etc/nginx \
 		--sbin-path=/usr/sbin/nginx \

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -915,25 +915,18 @@ static char *get_jwt(ngx_http_request_t *r, ngx_str_t jwt_location)
   }
   else if (jwt_location.len > strlen(COOKIE_PREFIX) && ngx_strncmp(jwt_location.data, COOKIE_PREFIX, strlen(COOKIE_PREFIX)) == 0)
   {
-    bool has_cookie = false;
     ngx_str_t jwtCookieVal;
 
     jwt_location.data += strlen(COOKIE_PREFIX);
     jwt_location.len -= strlen(COOKIE_PREFIX);
 
-#ifndef NGX_LINKED_LIST_COOKIES
-    if (ngx_http_parse_multi_header_lines(&r->headers_in.cookies, &jwt_location, &jwtCookieVal) != NGX_DECLINED)
-    {
-      has_cookie = true;
-    }
-#else
+#if nginx_version >= 1029006
+    if (ngx_http_parse_cookie_lines(r, r->headers_in.cookie, &jwt_location, &jwtCookieVal) != NULL)
+#elif nginx_version >= 1023000
     if (ngx_http_parse_multi_header_lines(r, r->headers_in.cookie, &jwt_location, &jwtCookieVal) != NULL)
-    {
-      has_cookie = true;
-    }
+#else
+    if (ngx_http_parse_multi_header_lines(&r->headers_in.cookies, &jwt_location, &jwtCookieVal) != NGX_DECLINED)
 #endif
-
-    if (has_cookie == true)
     {
       jwtPtr = ngx_str_t_to_char_ptr(r->pool, jwtCookieVal);
     }


### PR DESCRIPTION
nginx 1.29.6 introduced a dedicated header parser method for cookies.

Removed the `NGX_LINKED_LIST_COOKIES` compile option in favor of using the `nginx_version` macro to distinguish the cookie parser methods.